### PR TITLE
Implement basic queue creation

### DIFF
--- a/mq.2025/broker_node/src/broker/Broker.java
+++ b/mq.2025/broker_node/src/broker/Broker.java
@@ -43,7 +43,7 @@ class Broker extends UnicastRemoteObject implements MQSrv  {
         }
     }
     public synchronized Queue createQueue(String name, QueueType qc) throws RemoteException {
-        return null;
+        return new QueueImpl(this, name, qc);
     }
     public Collection <Queue> queueList() throws RemoteException {
         return null;

--- a/mq.2025/broker_node/src/broker/QueueImpl.java
+++ b/mq.2025/broker_node/src/broker/QueueImpl.java
@@ -11,13 +11,22 @@ import mqprot.Client;
 
 class QueueImpl extends UnicastRemoteObject implements Queue  {
     public static final long serialVersionUID=1234567890L;
+    private Broker broker;
+    private String name;
+    private QueueType qtype;
+    private java.util.ArrayList<Client> clients;
     public QueueImpl(Broker b, String qname, QueueType qtype) throws RemoteException {
+        super();
+        broker = b;
+        name = qname;
+        this.qtype = qtype;
+        clients = new java.util.ArrayList<>();
     }
     public String getName() throws RemoteException {
-        return null;
+        return name;
     }
     public QueueType getQueueType() throws RemoteException {
-        return null;
+        return qtype;
     }
     public void bind(Client cl) throws RemoteException {
     }


### PR DESCRIPTION
## Summary
- implement queue instantiation in Broker.createQueue
- flesh out QueueImpl constructor and getters

## Testing
- `./mq.2025/compile_all.sh`
- Manual test with `Test` client creating two queues

------
https://chatgpt.com/codex/tasks/task_e_6855bb8590b88323844b0098efd0a3f5