### PR TITLE
Implement client load tracking

### DIFF
--- a/mq.2025/broker_node/src/broker/QueueImpl.java
+++ b/mq.2025/broker_node/src/broker/QueueImpl.java
@@ -42,6 +42,7 @@ class QueueImpl extends UnicastRemoteObject implements Queue  {
             for (Client c : clients) {
                 try {
                     c.deliver(name, m);
+                    broker.incPending(c);
                 } catch (RemoteException e) {
                     // Ignore delivery errors at this stage
                 }


### PR DESCRIPTION
## Summary
- track pending messages per client on the broker
- update PUBSUB send logic to register deliveries

## Testing
- `sh mq.2025/compile_all.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855df10f04483239e41cb193658efd3